### PR TITLE
fix: block insert shortcuts during element placement

### DIFF
--- a/src/gui/adapters/GUIAdapter.js
+++ b/src/gui/adapters/GUIAdapter.js
@@ -438,6 +438,16 @@ export class GUIAdapter {
   }
 
   /**
+   * Whether insert/add-element actions should be ignored.
+   * Blocks shortcuts and menu actions while placing or editing properties.
+   * @return {boolean}
+   * @private
+   */
+  _isInsertBlocked() {
+    return !!(this.placingElement || this.propertyPanel?.isVisible);
+  }
+
+  /**
    * Execute a declarative action spec (from YAML/JSON).
    * @param {!ActionSpec} spec
    * @private
@@ -445,6 +455,10 @@ export class GUIAdapter {
   _exec(spec) {
     switch (spec.kind) {
       case "command": {
+        if (spec.name === "addElement" && this._isInsertBlocked()) {
+          return;
+        }
+
         // Special handling for wire drawing mode
         if (spec.name === "addElement" && spec.args && spec.args[0] === "Wire") {
           this.wireDrawingMode = true;

--- a/tests/gui/GUIAdapter.test.js
+++ b/tests/gui/GUIAdapter.test.js
@@ -166,4 +166,52 @@ describe('GUIAdapter (declarative actions)', () => {
     await nextTick();
     expect(true).to.equal(true); // no throw
   });
+
+  it('ignores insert shortcut while an element is being placed (#53)', async () => {
+    guiAdapter.initialize();
+
+    document.dispatchEvent(
+      new window.CustomEvent('ui:action', {
+        detail: { id: 'insert.resistor' },
+        bubbles: true,
+      })
+    );
+    await nextTick();
+
+    expect(guiAdapter.placingElement).to.exist;
+    const lenAfterFirst = circuitService.getElements().length;
+
+    document.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'r', bubbles: true })
+    );
+    await nextTick();
+
+    expect(circuitService.getElements().length).to.equal(lenAfterFirst);
+    expect(guiAdapter.placingElement).to.exist;
+  });
+
+  it('ignores insert action while property panel is open (#53)', async () => {
+    guiAdapter.initialize();
+
+    document.dispatchEvent(
+      new window.CustomEvent('ui:action', {
+        detail: { id: 'insert.resistor' },
+        bubbles: true,
+      })
+    );
+    await nextTick();
+
+    guiAdapter.propertyPanel = { isVisible: true };
+    const lenBefore = circuitService.getElements().length;
+
+    document.dispatchEvent(
+      new window.CustomEvent('ui:action', {
+        detail: { id: 'insert.capacitor' },
+        bubbles: true,
+      })
+    );
+    await nextTick();
+
+    expect(circuitService.getElements().length).to.equal(lenBefore);
+  });
 });


### PR DESCRIPTION
## Summary
- Block `addElement` actions (keyboard shortcuts and menu) while a component is being placed or the property panel is open
- Prevents orphan components from being created without entering required property data
## Problem
Fixes #53 — pressing an insert shortcut (e.g. `R`, `C`) while placing a new component could create additional elements on the canvas without opening the property dialog.
## Test plan
- [x] `tests/gui/GUIAdapter.test.js` — 2 new regression tests for #53
- [ ] Manual: press `R` to start placing a resistor, press `R`/`C` again before clicking to place → no extra element
- [ ] Manual: place a component, open property panel, press insert shortcut → no new element
- [ ] Manual: `Escape` still cancels placement; Ctrl+Arrow still rotates during placement