### PR TITLE
feat: add zh/en UI localization with language settings dialog

### DIFF
--- a/src/config/gui.config.yaml
+++ b/src/config/gui.config.yaml
@@ -251,3 +251,9 @@ menus:
         label: Re-center
         shortcut: Ctrl+R
         action: { kind: renderer, op: recenter }
+
+      - type: separator
+
+      - id: view.language
+        label: Language
+        action: { kind: localeDialog }

--- a/src/gui/adapters/GUIAdapter.js
+++ b/src/gui/adapters/GUIAdapter.js
@@ -25,6 +25,7 @@ import { PropertyPanel } from "../property_panel/PropertyPanel.js";
 import { Logger } from "../../utils/Logger.js";
 import { throttle } from "../../utils/PerformanceUtils.js";
 import { GRID_CONFIG } from "../../config/gridConfig.js";
+import { LanguageDialog } from "../components/LanguageDialog.js";
 
 
 /**
@@ -512,6 +513,11 @@ export class GUIAdapter {
 
       case "disabled": {
         // No-op for disabled menu items
+        break;
+      }
+
+      case "localeDialog": {
+        LanguageDialog.show();
         break;
       }
 

--- a/src/gui/commands/CopyNetlistToClipboardCommand.js
+++ b/src/gui/commands/CopyNetlistToClipboardCommand.js
@@ -1,5 +1,6 @@
 import { GUICommand } from './GUICommand.js';
 import { QucatNetlistAdapter } from '../../infrastructure/adapters/QucatNetlistAdapter.js';
+import { tr } from '../i18n/i18n.js';
 
 /**
  * CopyNetlistToClipboardCommand
@@ -30,7 +31,7 @@ export class CopyNetlistToClipboardCommand extends GUICommand {
             
             if (!circuit || circuit.elements.length === 0) {
                 console.warn('[CopyNetlistToClipboardCommand] No circuit elements to copy');
-                alert('No circuit elements to copy. Please add some components first.');
+                alert(tr('command.noElementsToCopy'));
                 return { undo: () => {} };
             }
 
@@ -45,7 +46,7 @@ export class CopyNetlistToClipboardCommand extends GUICommand {
             
         } catch (error) {
             console.error('[CopyNetlistToClipboardCommand] Error copying netlist to clipboard:', error);
-            alert(`Error copying netlist to clipboard: ${error.message}`);
+            alert(tr('command.copyError', { message: error.message }));
             return { undo: () => {} };
         }
     }
@@ -62,11 +63,11 @@ export class CopyNetlistToClipboardCommand extends GUICommand {
             navigator.clipboard.writeText(content)
                 .then(() => {
                     console.log('[CopyNetlistToClipboardCommand] Netlist copied to clipboard');
-                    this._showSuccessNotification('Netlist copied to clipboard');
+                    this._showSuccessNotification(tr('command.netlistCopied'));
                 })
                 .catch(err => {
                     console.error('[CopyNetlistToClipboardCommand] Failed to copy to clipboard:', err);
-                    this._showErrorNotification('Failed to copy to clipboard');
+                    this._showErrorNotification(tr('command.copyFailed'));
                 });
         } else {
             // Fallback to older method for browsers that don't support Clipboard API
@@ -92,14 +93,14 @@ export class CopyNetlistToClipboardCommand extends GUICommand {
             const successful = document.execCommand('copy');
             if (successful) {
                 console.log('[CopyNetlistToClipboardCommand] Netlist copied to clipboard (fallback method)');
-                this._showSuccessNotification('Netlist copied to clipboard');
+                this._showSuccessNotification(tr('command.netlistCopied'));
             } else {
                 console.error('[CopyNetlistToClipboardCommand] execCommand failed');
-                this._showErrorNotification('Failed to copy to clipboard');
+                this._showErrorNotification(tr('command.copyFailed'));
             }
         } catch (err) {
             console.error('[CopyNetlistToClipboardCommand] Fallback copy failed:', err);
-            this._showErrorNotification('Failed to copy to clipboard');
+            this._showErrorNotification(tr('command.copyFailed'));
         } finally {
             document.body.removeChild(textArea);
         }

--- a/src/gui/commands/OpenNetlistCommand.js
+++ b/src/gui/commands/OpenNetlistCommand.js
@@ -1,5 +1,6 @@
 import { GUICommand } from './GUICommand.js';
 import { QucatNetlistAdapter } from '../../infrastructure/adapters/QucatNetlistAdapter.js';
+import { tr } from '../i18n/i18n.js';
 
 /**
  * OpenNetlistCommand
@@ -51,7 +52,7 @@ export class OpenNetlistCommand extends GUICommand {
                     
                     if (!elements || elements.length === 0) {
                         console.warn('[OpenNetlistCommand] No valid elements found in netlist');
-                        alert('No valid circuit elements found in the selected file.');
+                        alert(tr('command.noValidElementsInFile'));
                         resolve({ undo: () => {} });
                         return;
                     }
@@ -70,7 +71,7 @@ export class OpenNetlistCommand extends GUICommand {
                     
                 } catch (error) {
                     console.error('[OpenNetlistCommand] Error loading netlist:', error);
-                    alert(`Error loading netlist file: ${error.message}`);
+                    alert(tr('command.loadError', { message: error.message }));
                     resolve({ undo: () => {} });
                 } finally {
                     // Clean up file input

--- a/src/gui/commands/PasteNetlistFromClipboardCommand.js
+++ b/src/gui/commands/PasteNetlistFromClipboardCommand.js
@@ -1,5 +1,6 @@
 import { GUICommand } from './GUICommand.js';
 import { QucatNetlistAdapter } from '../../infrastructure/adapters/QucatNetlistAdapter.js';
+import { tr } from '../i18n/i18n.js';
 
 /**
  * PasteNetlistFromClipboardCommand
@@ -46,7 +47,7 @@ export class PasteNetlistFromClipboardCommand extends GUICommand {
                         const elements = QucatNetlistAdapter.importFromString(netlistText);
 
                         if (!elements || elements.length === 0) {
-                            this._showErrorNotification('No valid circuit elements found in the pasted text.');
+                            this._showErrorNotification(tr('command.noValidElementsInPaste'));
                             resolve({ undo: () => {} });
                             return;
                         }
@@ -54,12 +55,12 @@ export class PasteNetlistFromClipboardCommand extends GUICommand {
                         this._loadElementsIntoCircuit(elements);
                         this.circuitService.emit('update');
                         this.circuitRenderer.render();
-                        this._showSuccessNotification(`Imported ${elements.length} element(s) from netlist.`);
+                        this._showSuccessNotification(tr('command.importSuccess', { count: elements.length }));
 
                         resolve({ undo: () => this.undo() });
                     } catch (error) {
                         console.error('[PasteNetlistFromClipboardCommand] Parse error:', error);
-                        this._showErrorNotification(`Invalid netlist: ${error.message}`);
+                        this._showErrorNotification(tr('command.invalidNetlist', { message: error.message }));
                         resolve({ undo: () => {} });
                     }
                 },
@@ -140,12 +141,12 @@ export class PasteNetlistFromClipboardCommand extends GUICommand {
 
         // Title
         const title = document.createElement('h3');
-        title.textContent = 'Paste Netlist';
+        title.textContent = tr('pasteDialog.title');
         title.style.cssText = 'margin: 0 0 8px; font-size: 16px; color: #2c3e50;';
 
         // Description
         const desc = document.createElement('p');
-        desc.textContent = 'Paste a QuCat netlist below (e.g. from a Jupyter cell) and click Import.';
+        desc.textContent = tr('pasteDialog.description');
         desc.style.cssText = 'margin: 0 0 12px; font-size: 13px; color: #666;';
 
         // Textarea
@@ -163,14 +164,14 @@ export class PasteNetlistFromClipboardCommand extends GUICommand {
         btnBar.style.cssText = 'display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px;';
 
         const btnCancel = document.createElement('button');
-        btnCancel.textContent = 'Cancel';
+        btnCancel.textContent = tr('pasteDialog.cancel');
         btnCancel.style.cssText = `
             padding: 8px 18px; border: 1px solid #ccc; border-radius: 4px;
             background: #fff; cursor: pointer; font-size: 13px;
         `;
 
         const btnImport = document.createElement('button');
-        btnImport.textContent = 'Import';
+        btnImport.textContent = tr('pasteDialog.import');
         btnImport.style.cssText = `
             padding: 8px 18px; border: none; border-radius: 4px;
             background: #3498db; color: #fff; cursor: pointer; font-size: 13px;

--- a/src/gui/commands/SaveNetlistCommand.js
+++ b/src/gui/commands/SaveNetlistCommand.js
@@ -1,5 +1,6 @@
 import { GUICommand } from './GUICommand.js';
 import { QucatNetlistAdapter } from '../../infrastructure/adapters/QucatNetlistAdapter.js';
+import { tr } from '../i18n/i18n.js';
 
 /**
  * SaveNetlistCommand
@@ -29,7 +30,7 @@ export class SaveNetlistCommand extends GUICommand {
             
             if (!circuit || circuit.elements.length === 0) {
                 console.warn('[SaveNetlistCommand] No circuit elements to save');
-                alert('No circuit elements to save. Please add some components first.');
+                alert(tr('command.noElementsToSave'));
                 return { undo: () => {} };
             }
 
@@ -45,7 +46,7 @@ export class SaveNetlistCommand extends GUICommand {
             
         } catch (error) {
             console.error('[SaveNetlistCommand] Error saving netlist:', error);
-            alert(`Error saving netlist: ${error.message}`);
+            alert(tr('command.saveError', { message: error.message }));
             return { undo: () => {} };
         }
     }

--- a/src/gui/components/LanguageDialog.js
+++ b/src/gui/components/LanguageDialog.js
@@ -1,0 +1,242 @@
+/**
+ * Language selection dialog — follows PropertyPanel / paste-dialog patterns.
+ */
+import { getLocale, setLocale, tr, LOCALE_OPTIONS } from '../i18n/i18n.js';
+
+export class LanguageDialog {
+  /**
+   * Open the language settings dialog.
+   * @param {{ onSave?: (locale: string) => void, onCancel?: () => void }} [callbacks]
+   */
+  static show(callbacks = {}) {
+    if (typeof document === 'undefined' || !document.body) return;
+    if (document.querySelector('.language-dialog-overlay')) return;
+
+    LanguageDialog._ensureStyles();
+
+    let selected = getLocale();
+
+    const overlay = document.createElement('div');
+    overlay.className = 'language-dialog-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'language-dialog';
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+
+    const header = document.createElement('div');
+    header.className = 'language-dialog-header';
+    const title = document.createElement('h3');
+    title.textContent = tr('languageDialog.title');
+    header.appendChild(title);
+
+    const content = document.createElement('div');
+    content.className = 'language-dialog-content';
+
+    const desc = document.createElement('p');
+    desc.className = 'language-dialog-desc';
+    desc.textContent = tr('languageDialog.description');
+    content.appendChild(desc);
+
+    const list = document.createElement('div');
+    list.className = 'language-dialog-list';
+    list.setAttribute('role', 'radiogroup');
+    list.setAttribute('aria-label', tr('languageDialog.title'));
+
+    const optionInputs = [];
+
+    for (const opt of LOCALE_OPTIONS) {
+      const row = document.createElement('label');
+      row.className = 'language-dialog-option';
+
+      const input = document.createElement('input');
+      input.type = 'radio';
+      input.name = 'jscircuit-locale';
+      input.value = opt.code;
+      input.checked = opt.code === selected;
+
+      input.addEventListener('change', () => {
+        if (input.checked) selected = opt.code;
+      });
+
+      const label = document.createElement('span');
+      label.textContent = opt.label;
+
+      row.append(input, label);
+      list.appendChild(row);
+      optionInputs.push(input);
+    }
+
+    content.appendChild(list);
+
+    const actions = document.createElement('div');
+    actions.className = 'language-dialog-actions';
+
+    const btnCancel = document.createElement('button');
+    btnCancel.type = 'button';
+    btnCancel.className = 'language-dialog-cancel';
+    btnCancel.textContent = tr('languageDialog.cancel');
+
+    const btnSave = document.createElement('button');
+    btnSave.type = 'button';
+    btnSave.className = 'language-dialog-save';
+    btnSave.textContent = tr('languageDialog.save');
+
+    actions.append(btnCancel, btnSave);
+    dialog.append(header, content, actions);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    const close = () => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+    };
+
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+        callbacks.onCancel?.();
+      }
+    };
+
+    btnCancel.addEventListener('click', () => {
+      close();
+      callbacks.onCancel?.();
+    });
+
+    btnSave.addEventListener('click', () => {
+      close();
+      setLocale(selected);
+      callbacks.onSave?.(selected);
+    });
+
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) {
+        close();
+        callbacks.onCancel?.();
+      }
+    });
+
+    document.addEventListener('keydown', onKeyDown, true);
+    optionInputs.find((input) => input.checked)?.focus();
+  }
+
+  /** @private */
+  static _ensureStyles() {
+    if (document.getElementById('language-dialog-styles')) return;
+
+    const style = document.createElement('style');
+    style.id = 'language-dialog-styles';
+    style.textContent = `
+      .language-dialog-overlay {
+        position: fixed;
+        inset: 0;
+        background-color: rgba(0, 0, 0, 0.5);
+        z-index: 10002;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      }
+
+      .language-dialog {
+        background: #fff;
+        border-radius: 14px;
+        box-shadow: 0 14px 40px rgba(0,0,0,.28), 0 6px 16px rgba(0,0,0,.25);
+        width: 400px;
+        max-width: 90vw;
+        border: 1px solid #d0d0d0;
+        overflow: hidden;
+      }
+
+      .language-dialog-header {
+        background: linear-gradient(#ecf3fb, #dbe6f4);
+        padding: 12px 20px;
+        border-bottom: 1px solid #c5d2e2;
+      }
+
+      .language-dialog-header h3 {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 600;
+        color: #161616;
+      }
+
+      .language-dialog-content {
+        padding: 20px;
+      }
+
+      .language-dialog-desc {
+        margin: 0 0 16px;
+        font-size: 13px;
+        color: #555;
+        line-height: 1.4;
+      }
+
+      .language-dialog-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .language-dialog-option {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 12px;
+        border: 1px solid #d0d0d0;
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 14px;
+        color: #161616;
+        transition: background 120ms ease;
+      }
+
+      .language-dialog-option:hover {
+        background: rgba(0, 0, 0, 0.04);
+      }
+
+      .language-dialog-option input {
+        margin: 0;
+        accent-color: #3498db;
+      }
+
+      .language-dialog-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        padding: 0 20px 20px;
+      }
+
+      .language-dialog-cancel,
+      .language-dialog-save {
+        padding: 8px 18px;
+        border-radius: 6px;
+        font-size: 13px;
+        cursor: pointer;
+      }
+
+      .language-dialog-cancel {
+        border: 1px solid #ccc;
+        background: #fff;
+        color: #161616;
+      }
+
+      .language-dialog-save {
+        border: none;
+        background: #3498db;
+        color: #fff;
+      }
+
+      .language-dialog-cancel:hover {
+        background: #f5f5f5;
+      }
+
+      .language-dialog-save:hover {
+        background: #2980b9;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+}

--- a/src/gui/i18n/i18n.js
+++ b/src/gui/i18n/i18n.js
@@ -1,0 +1,190 @@
+/**
+ * Lightweight i18n for JSCircuit GUI (English / Simplified Chinese).
+ */
+import zh from './locales/zh.js';
+
+const STORAGE_KEY = 'jscircuit.locale';
+const SUPPORTED = ['en', 'zh'];
+
+/** Available languages shown in the settings dialog. */
+export const LOCALE_OPTIONS = [
+  { code: 'en', label: 'English' },
+  { code: 'zh', label: '中文' },
+];
+
+/** @type {Record<string, object>} */
+const CATALOGS = { zh };
+
+/** @type {'en'|'zh'} */
+let currentLocale = 'en';
+
+/**
+ * Read a nested value by dot-separated path.
+ * @param {object} obj
+ * @param {string} path
+ * @returns {string|undefined}
+ */
+function getByPath(obj, path) {
+  return path.split('.').reduce((acc, key) => (acc && acc[key] !== undefined ? acc[key] : undefined), obj);
+}
+
+/**
+ * Replace `{name}` placeholders in a template string.
+ * @param {string} template
+ * @param {Record<string, string|number>} [vars]
+ */
+function interpolate(template, vars = {}) {
+  return template.replace(/\{(\w+)\}/g, (_, key) => String(vars[key] ?? `{${key}}`));
+}
+
+/**
+ * Look up a menu-item label by id (ids may contain dots, e.g. view.zoomIn).
+ * @param {string} id
+ * @param {string} fallback
+ */
+function lookupMenuItemTranslation(id, fallback) {
+  if (currentLocale === 'en') return fallback;
+  const items = CATALOGS[currentLocale]?.menuItem;
+  if (items && typeof items[id] === 'string') return items[id];
+  return fallback;
+}
+
+/**
+ * Initialize locale from localStorage or browser language.
+ */
+export function initI18n() {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored && SUPPORTED.includes(stored)) {
+    currentLocale = /** @type {'en'|'zh'} */ (stored);
+  } else {
+    const browserLang = (navigator.language || 'en').toLowerCase();
+    currentLocale = browserLang.startsWith('zh') ? 'zh' : 'en';
+  }
+  applyDocumentLocale();
+}
+
+/** @returns {'en'|'zh'} */
+export function getLocale() {
+  return currentLocale;
+}
+
+/**
+ * Switch UI language and notify listeners.
+ * @param {'en'|'zh'} locale
+ */
+export function setLocale(locale) {
+  if (!SUPPORTED.includes(locale) || locale === currentLocale) return;
+  currentLocale = /** @type {'en'|'zh'} */ (locale);
+  localStorage.setItem(STORAGE_KEY, currentLocale);
+  applyDocumentLocale();
+  document.dispatchEvent(new CustomEvent('locale:change', { detail: { locale: currentLocale } }));
+}
+
+function applyDocumentLocale() {
+  document.documentElement.lang = currentLocale === 'zh' ? 'zh-CN' : 'en';
+  document.title = tr('app.title');
+}
+
+/**
+ * Translate a dot-path key. Falls back to English default or the key itself.
+ * @param {string} key
+ * @param {Record<string, string|number>} [vars]
+ * @param {string} [fallback]
+ */
+export function t(key, vars, fallback) {
+  const fb = fallback ?? key;
+  if (currentLocale === 'en') {
+    return typeof vars === 'object' && vars !== null ? interpolate(fb, vars) : fb;
+  }
+  const value = getByPath(CATALOGS[currentLocale], key);
+  if (typeof value !== 'string') return fb;
+  return typeof vars === 'object' && vars !== null ? interpolate(value, vars) : value;
+}
+
+/** English defaults used when locale is `en`. */
+const EN_DEFAULTS = {
+  'app.title': 'Circuit Designer',
+  'propertyPanel.header': 'Circuit Editor',
+  'propertyPanel.cancel': 'Cancel',
+  'propertyPanel.ok': 'OK',
+  'propertyPanel.fallbackTitle': 'Configure {type} properties',
+  'propertyPanel.labelField': 'Label',
+  'propertyPanel.labelPlaceholder': 'Enter element label',
+  'propertyPanel.warning.title': '⚠️ Incomplete Properties',
+  'propertyPanel.warning.intro': 'Please specify at least one of the following:',
+  'propertyPanel.warning.labelItem': 'A label for the component',
+  'propertyPanel.warning.propertyItem': 'A property value (resistance, capacitance, etc.)',
+  'propertyPanel.warning.footer':
+    'This ensures the component can be properly identified and used in the circuit.',
+  'propertyPanel.warning.ok': 'OK',
+  'pasteDialog.title': 'Paste Netlist',
+  'pasteDialog.description':
+    'Paste a QuCat netlist below (e.g. from a Jupyter cell) and click Import.',
+  'pasteDialog.cancel': 'Cancel',
+  'pasteDialog.import': 'Import',
+  'languageDialog.title': 'Language',
+  'languageDialog.description': 'Select the display language for menus and dialogs.',
+  'languageDialog.cancel': 'Cancel',
+  'languageDialog.save': 'Save',
+  'command.noElementsToCopy': 'No circuit elements to copy. Please add some components first.',
+  'command.copyError': 'Error copying netlist to clipboard: {message}',
+  'command.netlistCopied': 'Netlist copied to clipboard',
+  'command.copyFailed': 'Failed to copy to clipboard',
+  'command.noElementsToSave': 'No circuit elements to save. Please add some components first.',
+  'command.saveError': 'Error saving netlist: {message}',
+  'command.noValidElementsInFile': 'No valid circuit elements found in the selected file.',
+  'command.loadError': 'Error loading netlist file: {message}',
+  'command.noValidElementsInPaste': 'No valid circuit elements found in the pasted text.',
+  'command.importSuccess': 'Imported {count} element(s) from netlist.',
+  'command.invalidNetlist': 'Invalid netlist: {message}',
+};
+
+/**
+ * Translate with built-in English default.
+ * @param {string} key
+ * @param {Record<string, string|number>} [vars]
+ */
+export function tr(key, vars) {
+  return t(key, vars, EN_DEFAULTS[key] ?? key);
+}
+
+/**
+ * Return a deep-cloned, localized copy of gui.config.
+ * @param {object} config
+ */
+export function localizeGuiConfig(config) {
+  const c = JSON.parse(JSON.stringify(config));
+
+  if (currentLocale === 'en') return c;
+
+  for (const menu of c.menus) {
+    const menuLabel = t(`menu.${menu.label}`, undefined, menu.label);
+    menu.label = menuLabel;
+    for (const item of menu.items) {
+      if (item.id && item.label) {
+        item.label = lookupMenuItemTranslation(item.id, item.label);
+      }
+    }
+  }
+
+  for (const [key, comp] of Object.entries(c.components)) {
+    if (comp.menuLabel) {
+      comp.menuLabel = t(`component.${key}.menuLabel`, undefined, comp.menuLabel);
+    }
+    const pp = comp.propertyPanel;
+    if (!pp) continue;
+    if (pp.title) pp.title = t(`component.${key}.propertyPanel.title`, undefined, pp.title);
+    if (pp.description) {
+      pp.description = t(`component.${key}.propertyPanel.description`, undefined, pp.description);
+    }
+    if (pp.helpText) {
+      pp.helpText = t(`component.${key}.propertyPanel.helpText`, undefined, pp.helpText);
+    }
+    for (const field of pp.fields || []) {
+      const fieldKey = `component.${key}.propertyPanel.field.${field.key}`;
+      field.label = t(fieldKey, undefined, field.label);
+    }
+  }
+
+  return c;
+}

--- a/src/gui/i18n/locales/zh.js
+++ b/src/gui/i18n/locales/zh.js
@@ -1,0 +1,138 @@
+/**
+ * Simplified Chinese translations for JSCircuit GUI.
+ * English strings remain the source of truth in gui.config.yaml.
+ */
+export default {
+  app: {
+    title: '电路设计器',
+  },
+
+  menu: {
+    File: '文件',
+    Edit: '编辑',
+    Insert: '插入',
+    View: '视图',
+  },
+
+  menuItem: {
+    openNetlist: '打开网表...',
+    saveNetlist: '保存网表...',
+    copyNetlistToClipboard: '复制网表',
+    pasteNetlistFromClipboard: '粘贴网表...',
+    deleteAll: '清空全部',
+    selectAll: '全选',
+    deselectAll: '取消全选',
+    copyElements: '复制',
+    pasteElements: '粘贴',
+    'edit.undo': '撤销',
+    'edit.redo': '重做',
+    deleteSelection: '删除',
+    nudgeRight: '右移',
+    nudgeLeft: '左移',
+    nudgeUp: '上移',
+    nudgeDown: '下移',
+    rotateElement: '旋转元件',
+    rotateElementRight: '向右旋转',
+    rotateElementLeft: '向左旋转',
+    rotateElementUp: '向上旋转',
+    rotateElementDown: '向下旋转',
+    'view.zoomIn': '放大',
+    'view.zoomOut': '缩小',
+    'view.recenter': '重新居中',
+    'view.language': '语言',
+  },
+
+  component: {
+    wire: {
+      menuLabel: '导线',
+      propertyPanel: {
+        title: '导线属性',
+        description: '理想导体导线',
+        helpText: '导线没有可配置的电气参数',
+      },
+    },
+    junction: {
+      menuLabel: '约瑟夫森结',
+      propertyPanel: {
+        title: '指定标签和/或约瑟夫森电感（单位：亨利）',
+        description: '注意 L = (hbar/2e)**2/[约瑟夫森能量，单位：焦耳]',
+        field: { inductance: '电感', label: '标签' },
+      },
+    },
+    inductor: {
+      menuLabel: '电感',
+      propertyPanel: {
+        title: '指定标签和/或电感（单位：亨利）',
+        description: '注意 L = (hbar/2e)**2/[约瑟夫森能量，单位：焦耳]',
+        field: { inductance: '电感', label: '标签' },
+      },
+    },
+    capacitor: {
+      menuLabel: '电容',
+      propertyPanel: {
+        title: '指定标签和/或电容（单位：法拉）',
+        field: { capacitance: '电容', label: '标签' },
+      },
+    },
+    resistor: {
+      menuLabel: '电阻',
+      propertyPanel: {
+        title: '指定标签和/或电阻（单位：欧姆）',
+        field: { resistance: '电阻', label: '标签' },
+      },
+    },
+    ground: {
+      menuLabel: '接地',
+      propertyPanel: {
+        title: '接地属性',
+        description: '参考点（0V）',
+        helpText: '接地没有可配置的电气参数',
+      },
+    },
+  },
+
+  propertyPanel: {
+    header: '电路编辑器',
+    cancel: '取消',
+    ok: '确定',
+    fallbackTitle: '配置 {type} 属性',
+    labelField: '标签',
+    labelPlaceholder: '输入元件标签',
+    warning: {
+      title: '⚠️ 属性不完整',
+      intro: '请至少指定以下一项：',
+      labelItem: '元件的标签',
+      propertyItem: '属性值（电阻、电容等）',
+      footer: '这有助于在电路中正确识别和使用该元件。',
+      ok: '确定',
+    },
+  },
+
+  pasteDialog: {
+    title: '粘贴网表',
+    description: '在下方粘贴 QuCat 网表（例如从 Jupyter 单元格复制），然后点击导入。',
+    cancel: '取消',
+    import: '导入',
+  },
+
+  languageDialog: {
+    title: '语言',
+    description: '选择菜单和对话框的显示语言。',
+    cancel: '取消',
+    save: '保存',
+  },
+
+  command: {
+    noElementsToCopy: '没有可复制的电路元件，请先添加一些元件。',
+    copyError: '复制网表到剪贴板时出错：{message}',
+    netlistCopied: '网表已复制到剪贴板',
+    copyFailed: '复制到剪贴板失败',
+    noElementsToSave: '没有可保存的电路元件，请先添加一些元件。',
+    saveError: '保存网表时出错：{message}',
+    noValidElementsInFile: '所选文件中没有有效的电路元件。',
+    loadError: '加载网表文件时出错：{message}',
+    noValidElementsInPaste: '粘贴的文本中没有有效的电路元件。',
+    importSuccess: '已从网表导入 {count} 个元件。',
+    invalidNetlist: '无效的网表：{message}',
+  },
+};

--- a/src/gui/main.js
+++ b/src/gui/main.js
@@ -57,6 +57,7 @@ import {
   setupCommands
 } from "../config/registry.js";
 import { initMenu } from "./menu/initMenu.js";
+import { initI18n } from "./i18n/i18n.js";
 import { Logger } from "../utils/Logger.js";
 import { globalPerformanceMonitor } from "../utils/PerformanceUtils.js";
 
@@ -148,7 +149,8 @@ const guiAdapter = new GUIAdapter(                // GUI: Primary adapter
   GUICommandRegistry
 );
 
-/* ---------- Menu (emits ui:action only) ---------- */
+/* ---------- i18n + Menu (emits ui:action only) ---------- */
+initI18n();
 initMenu();
 
 /* ---------- Commands, first render, reveal, THEN start resize observer ---------- */

--- a/src/gui/menu/initMenu.js
+++ b/src/gui/menu/initMenu.js
@@ -1,6 +1,7 @@
 // static/initMenu.js
 import { MenuBar } from "./MenuBar.js";
 import guiConfig from "../../config/gui.config.js";
+import { localizeGuiConfig } from "../i18n/i18n.js";
 
 /**
  * Expands component references in menu items to full menu item definitions
@@ -38,17 +39,28 @@ function expandComponentReferences(guiConfig) {
   return { ...guiConfig, menus: expandedMenus };
 }
 
+function buildMenuConfig() {
+  const localized = localizeGuiConfig(guiConfig);
+  return expandComponentReferences(localized);
+}
+
+/** @type {MenuBar|null} */
+let menuInstance = null;
+
+function renderMenu() {
+  const config = buildMenuConfig();
+  if (!menuInstance) {
+    menuInstance = new MenuBar(document.getElementById("menubar"));
+  }
+  menuInstance.renderFromConfig(config);
+}
+
 export function initMenu() {
-  // Configuration is now statically imported at build time
-  // No runtime fetch needed - fully embedded in bundle
-  const expandedConfig = expandComponentReferences(guiConfig);
-  
-  const menu = new MenuBar(document.getElementById("menubar"));
-  menu.renderFromConfig(expandedConfig);
+  renderMenu();
+  document.addEventListener("locale:change", renderMenu);
 
   // Note: Keyboard shortcuts are handled by GUIAdapter.bindShortcuts()
   // to avoid double-binding. The menu only handles click events.
 
-  return menu; // so you can enable/disable items later: menu.update("edit.copy",{disabled:false})
+  return menuInstance; // so you can enable/disable items later: menu.update("edit.copy",{disabled:false})
 }
-

--- a/src/gui/property_panel/PropertyPanel.js
+++ b/src/gui/property_panel/PropertyPanel.js
@@ -7,6 +7,7 @@ import { CircuitService } from '../../application/CircuitService.js';
 import { UpdateElementPropertiesCommand } from '../commands/UpdateElementPropertiesCommand.js';
 import { CommandHistory } from '../commands/CommandHistory.js';
 import guiConfig from '../../config/gui.config.js';
+import { localizeGuiConfig, tr } from '../i18n/i18n.js';
 
 /**
  * PropertyPanel class for displaying and editing element properties
@@ -29,7 +30,7 @@ export class PropertyPanel {
      * @private
      */
     getConfig() {
-        return guiConfig;
+        return localizeGuiConfig(guiConfig);
     }
 
     /**
@@ -141,7 +142,7 @@ export class PropertyPanel {
 
         return `
             <div class="property-panel-header">
-                <h3>Circuit Editor</h3>
+                <h3>${tr('propertyPanel.header')}</h3>
             </div>
             <div class="property-panel-content">
                 <div class="property-panel-title">
@@ -152,8 +153,8 @@ export class PropertyPanel {
                 ${propertyFields}
             </div>
             <div class="property-panel-actions">
-                <button type="button" class="cancel-btn">Cancel</button>
-                <button type="button" class="ok-btn">OK</button>
+                <button type="button" class="cancel-btn">${tr('propertyPanel.cancel')}</button>
+                <button type="button" class="ok-btn">${tr('propertyPanel.ok')}</button>
             </div>
         `;
     }
@@ -172,22 +173,22 @@ export class PropertyPanel {
         
         return `
             <div class="property-panel-header">
-                <h3>Circuit Editor</h3>
+                <h3>${tr('propertyPanel.header')}</h3>
             </div>
             <div class="property-panel-content">
                 <div class="property-panel-title">
-                    <em>Configure ${elementType} properties</em>
+                    <em>${tr('propertyPanel.fallbackTitle', { type: elementType })}</em>
                 </div>
                 <div class="property-field">
-                    <label for="label">Label</label>
+                    <label for="label">${tr('propertyPanel.labelField')}</label>
                     <input type="text" id="label" name="label" 
                            value="${currentLabel}" 
-                           placeholder="Enter element label">
+                           placeholder="${tr('propertyPanel.labelPlaceholder')}">
                 </div>
             </div>
             <div class="property-panel-actions">
-                <button type="button" class="cancel-btn">Cancel</button>
-                <button type="button" class="ok-btn">OK</button>
+                <button type="button" class="cancel-btn">${tr('propertyPanel.cancel')}</button>
+                <button type="button" class="ok-btn">${tr('propertyPanel.ok')}</button>
             </div>
         `;
     }
@@ -290,18 +291,18 @@ export class PropertyPanel {
         
         warningDialog.innerHTML = `
             <div class="warning-header">
-                <h4>⚠️ Incomplete Properties</h4>
+                <h4>${tr('propertyPanel.warning.title')}</h4>
             </div>
             <div class="warning-content">
-                <p>Please specify at least one of the following:</p>
+                <p>${tr('propertyPanel.warning.intro')}</p>
                 <ul>
-                    <li>A label for the component</li>
-                    <li>A property value (resistance, capacitance, etc.)</li>
+                    <li>${tr('propertyPanel.warning.labelItem')}</li>
+                    <li>${tr('propertyPanel.warning.propertyItem')}</li>
                 </ul>
-                <p>This ensures the component can be properly identified and used in the circuit.</p>
+                <p>${tr('propertyPanel.warning.footer')}</p>
             </div>
             <div class="warning-actions">
-                <button type="button" class="warning-ok-btn">OK</button>
+                <button type="button" class="warning-ok-btn">${tr('propertyPanel.warning.ok')}</button>
             </div>
         `;
         


### PR DESCRIPTION
## Summary
- Add lightweight i18n module with English (default) and Simplified Chinese
- Localize menus, property panel, command messages, and paste-netlist dialog
- Add **View > Language** settings dialog with radio list and Save/Cancel
## Details
- Locale persisted in `localStorage` (`jscircuit.locale`); auto-detects browser language on first visit
- Menu re-renders on `locale:change` without page reload
- Junction menu label translated as 约瑟夫森结 in Chinese
## Test plan
- [ ] `npm run menu:build && npm test`
- [ ] Manual: View > Language → switch to 中文 → menus and dialogs show Chinese
- [ ] Manual: Save persists choice after refresh; Cancel discards changes
- [ ] Manual: English mode unchanged from current behavior